### PR TITLE
Events

### DIFF
--- a/lib/tools/phantomas/custom_modules/modules/eventYLT/eventYLT.js
+++ b/lib/tools/phantomas/custom_modules/modules/eventYLT/eventYLT.js
@@ -39,7 +39,7 @@ exports.module = function(phantomas) {
                     });
 
                     // count window.addEventListener('scroll', ...) - issue #508
-                    if (eventType === 'scroll' && path === 'window') {
+                    if (eventType === 'scroll' && (path === 'window' || path === '#document')) {
                         phantomas.incrMetric('eventsScrollBound');
                         phantomas.addOffender('eventsScrollBound', 'bound by %s', phantomas.getBacktrace());
                     }

--- a/lib/tools/phantomas/custom_modules/modules/eventYLT/eventYLT.js
+++ b/lib/tools/phantomas/custom_modules/modules/eventYLT/eventYLT.js
@@ -3,18 +3,20 @@
  */
 /* global Document: true, Element: true, window: true */
 
-exports.version = '0.2.a';
+exports.version = '0.4.a';
 
 exports.module = function(phantomas) {
     'use strict';
     
     phantomas.setMetric('eventsBound'); // @desc number of EventTarget.addEventListener calls
+    phantomas.setMetric('eventsDispatched'); // @desc number of EventTarget.dispatchEvent calls
+    phantomas.setMetric('eventsScrollBound'); // @desc number of scroll event bounds
 
-    // spy calls to EventTarget.addEventListener
-    // @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.addEventListener
     phantomas.once('init', function() {
         phantomas.evaluate(function() {
             (function(phantomas) {
+                // spy calls to EventTarget.addEventListener
+                // @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.addEventListener
                 function eventSpyBefore(eventType) {
                     /* jshint validthis: true */
                     var path = phantomas.getDOMPath(this);
@@ -22,6 +24,7 @@ exports.module = function(phantomas) {
 
                     phantomas.incrMetric('eventsBound');
                     phantomas.addOffender('eventsBound', '"%s" bound to "%s"', eventType, path);
+                    phantomas.log('event ' + eventType + ' bound');
 
                     phantomas.enterContext({
                         type: 'addEventListener',
@@ -34,6 +37,12 @@ exports.module = function(phantomas) {
                         },
                         backtrace: phantomas.getBacktrace()
                     });
+
+                    // count window.addEventListener('scroll', ...) - issue #508
+                    if (eventType === 'scroll' && path === 'window') {
+                        phantomas.incrMetric('eventsScrollBound');
+                        phantomas.addOffender('eventsScrollBound', 'bound by %s', phantomas.getBacktrace());
+                    }
                 }
 
                 function eventSpyAfter(result) {
@@ -43,6 +52,18 @@ exports.module = function(phantomas) {
                 phantomas.spy(Element.prototype, 'addEventListener', eventSpyBefore, eventSpyAfter);
                 phantomas.spy(Document.prototype, 'addEventListener', eventSpyBefore, eventSpyAfter);
                 phantomas.spy(window, 'addEventListener', eventSpyBefore, eventSpyAfter);
+
+                // spy calls to EventTarget.dispatchEvent
+                // @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.dispatchEvent
+                phantomas.spy(Element.prototype, 'dispatchEvent', function(ev) {
+                    /* jshint validthis: true */
+                    var path = phantomas.getDOMPath(this);
+
+                    phantomas.log('Core JS event: triggered "%s" on "%s"', ev.type, path);
+
+                    phantomas.incrMetric('eventsDispatched');
+                    phantomas.addOffender('eventsDispatched', '"%s" on "%s"', ev.type, path);
+                });
             })(window.__phantomas);
         });
     });

--- a/lib/tools/phantomas/phantomasWrapper.js
+++ b/lib/tools/phantomas/phantomasWrapper.js
@@ -39,7 +39,7 @@ var PhantomasWrapper = function() {
                 'domHiddenContent', // overriden
                 'domMutations', // not compatible with webkit
                 'domQueries', // overriden
-                'eventListeners', // overridden
+                'events', // overridden
                 'filmStrip', // not needed
                 'har', // not needed for the moment
                 'javaScriptBottlenecks', // needs to be launched after custom module scopeYLT


### PR DESCRIPTION
- Fix a bug with events being counted twice
- Bring the new metric `eventsScrollBound` from Phantomas 1.10.1
- Add binding on `document` to `eventsScrollBound`