### PR TITLE
Change default user agent

### DIFF
--- a/lib/tools/phantomas/phantomasWrapper.js
+++ b/lib/tools/phantomas/phantomasWrapper.js
@@ -23,7 +23,7 @@ var PhantomasWrapper = function() {
             'engine': task.options.phantomasEngine || 'webkit',
             'timeout': task.options.timeout || 30,
             'js-deep-analysis': task.options.jsDeepAnalysis || false,
-            'user-agent': (task.options.device === 'desktop') ? 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.110 Safari/537.36' : null,
+            'user-agent': (task.options.device === 'desktop') ? 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) YLT Chrome/27.0.1453.110 Safari/537.36' : null,
             'tablet': (task.options.device === 'tablet'),
             'phone': (task.options.device === 'phone'),
             'screenshot': task.options.screenshot || false,


### PR DESCRIPTION
Hi,

I've run into a simple problem with the tool when testing on local projects, basically (and i think i'm not the only one) i've got a different configuration between production and development environment.

For example i don't link the compressed javascript in development but to individual files to increase reactivity when developping. I tried to detect efficiently phantomas in order to simulate a prod environment on my dev machine but the user agent is too "classic".

So here is a proposal to add a "YTL" element in the user agent that could be easily detected by the website.