### PR TITLE
Fix a bug when analyzing an SVG with a syntax error

### DIFF
--- a/lib/tools/redownload/imageOptimizer.js
+++ b/lib/tools/redownload/imageOptimizer.js
@@ -219,7 +219,9 @@ var ImageOptimizer = function() {
         })
 
         .catch(function(err) {
-            deferred.reject(file);
+            debug('Optimisation failed:');
+            debug(err);
+            deferred.resolve();
         });
 
         return deferred.promise;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yellowlabtools",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Online tool to audit a webpage for performance and front-end quality issues",
   "license": "GPL-2.0",
   "author": {


### PR DESCRIPTION
When a page loads a bad SVG file the test could run forever. This should fix the problem.