### PR TITLE
Fix bug with EJS on grunt-built instances

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -243,7 +243,11 @@ module.exports = function(grunt) {
             build: {
                 options: {
                     base: '.tmp',
-                    method: 'append'
+                    method: 'append',
+                    unescape: {
+                        '&lt;': '<',
+                        '&gt;': '>'
+                    }
                 },
                 files: {
                     './front/build/main.html': ['.tmp/views/*.html']

--- a/front/src/main.html
+++ b/front/src/main.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://api.github.com">
     <link rel="dns-prefetch" href="https://api.github.com">
 
-<head>
+</head>
 
 <body ng-app="YellowLabTools">
     <div id="header"><h1>Yellow Lab <span class="icon-lab"></span> Tools</h1></div>


### PR DESCRIPTION
This is a fix for #189. The problem was with the [https://github.com/wmluke/grunt-inline-angular-templates](grunt-inline-angular-templates) module.

As it's not maintained and there are other ways to do the same thing, I'll get rid of it when I get a little more time.