### PR TITLE
Fix Error 1001: JavaScript profiling failed

### DIFF
--- a/front/src/views/index.html
+++ b/front/src/views/index.html
@@ -37,7 +37,7 @@
                     Cookie
                     <span class="settingsTooltip">
                         <span class="icon-question"></span>
-                        <div><b>Cookie</b><br><br>Adds a cookie on the main domain.<br><br>Example: "bar=foo;domain=url"</div>
+                        <div><b>Cookie</b><br><br>Adds a single cookie (on the main domain if you don't provide the domain).<br><br>Example: "bar=foo;domain=.something.com"</div>
                     </span>
                 </div>
                 <div><input type="text" name="cookie" ng-model="settings.cookie" /></div>

--- a/lib/tools/phantomas/custom_modules/modules/domQYLT/domQYLT.js
+++ b/lib/tools/phantomas/custom_modules/modules/domQYLT/domQYLT.js
@@ -39,9 +39,9 @@ exports.module = function(phantomas) {
                     });
 
                 }, function(result, args) {
-                    var id = args[0];
+                    var id = args ? '#' + args[0] : undefined;
 
-                    querySpy('id', '#' + id, 'getElementById', '#document', (result === null));
+                    querySpy('id', id, 'getElementById', '#document', (result === null));
 
                     var moreData = {
                         resultsNumber : (result === null) ? 0 : 1
@@ -74,10 +74,10 @@ exports.module = function(phantomas) {
                 function selectorClassNameAfter(result, args) {
                     /*jshint validthis: true */
 
-                    var className = args[0];
+                    var className = args ? '.' + args[0] : undefined;
                     var context = phantomas.getDOMPath(this);
 
-                    querySpy('class', '.' + className, 'getElementsByClassName', context, (result.length === 0));
+                    querySpy('class', className, 'getElementsByClassName', context, (result.length === 0));
                     
                     var moreData = {
                         resultsNumber : (result && result.length > 0) ? result.length : 0
@@ -113,10 +113,10 @@ exports.module = function(phantomas) {
                 function selectorTagNameSpyAfter(result, args) {
                     /*jshint validthis: true */
                     
-                    var tagName = args[0];
+                    var tagName = args ? args[0].toLowerCase() : undefined;
                     var context = phantomas.getDOMPath(this);
 
-                    querySpy('tag name', tagName.toLowerCase(), 'getElementsByTagName', context, (result.length === 0));
+                    querySpy('tag name', tagName, 'getElementsByTagName', context, (result.length === 0));
                     
                     var moreData = {
                         resultsNumber : (result && result.length > 0) ? result.length : 0
@@ -156,7 +156,7 @@ exports.module = function(phantomas) {
                 function selectorQuerySpyAfter(result, args) {
                     /*jshint validthis: true */
 
-                    var selector = args[0];
+                    var selector = args ? args[0] : undefined;
                     var context = phantomas.getDOMPath(this);
 
                     querySpy('selector', selector, 'querySelectorAll', context, (!result || result.length === 0));
@@ -189,7 +189,7 @@ exports.module = function(phantomas) {
                 function selectorAllQuerySpryAfter(result, args) {
                     /*jshint validthis: true */
 
-                    var selector = args[0];
+                    var selector = args ? args[0] : undefined;
                     var context = phantomas.getDOMPath(this);
 
                     querySpy('selector', selector, 'querySelectorAll', context, (!result || result.length === 0));

--- a/test/core/indexTest.js
+++ b/test/core/indexTest.js
@@ -109,6 +109,21 @@ describe('index.js', function() {
             });
     });
 
+    it('should succeed on try-catch.html', function(done) {
+        this.timeout(15000);
+
+        var url = 'http://localhost:8388/try-catch.html';
+
+        ylt(url)
+            .then(function(data) {
+                data.toolsResults.phantomas.metrics.should.have.a.property('jsErrors').that.equals(0);
+                done();
+            }).fail(function(err) {
+                console.log.restore();
+                done(err);
+            });
+    });
+
     it('should take a screenshot', function(done) {
         this.timeout(15000);
 

--- a/test/www/try-catch.html
+++ b/test/www/try-catch.html
@@ -1,0 +1,21 @@
+<html>
+    <head>
+        <title>Testing getElementById with a try catch statement</title>
+    </head>
+    <body>
+        <div id="foo">Some text</div>
+        <script>
+            try {
+                document.getElementById(undefined);
+                document.getElementsByClassName(undefined);
+                document.getElementsByTagName(undefined);
+                
+            } catch(err) {
+                console.log('Error found: ' + err);
+                throw new Error("I detect an error!");
+            }
+
+            document.getElementById('foo');
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This fix is supposed to repair the 1001 error that could occur on some webpages (#170 & #196).

The error was happening in a particular case, when getElementById/getElementsByClassName/getElemetsByTagName was called with a null or undefined argument, **and** inside a try-catch block.

(+ a small change in wording about setting cookies)