### PR TITLE
Add a way to block some urls to avoid spam

### DIFF
--- a/front/src/js/services/apiService.js
+++ b/front/src/js/services/apiService.js
@@ -37,6 +37,8 @@ apiService.factory('API', ['$location', 'Runs', 'Results', function($location, R
             }, function(response) {
                 if (response.status === 429) {
                     alert('Too many requests, you reached the max number of requests allowed in 24h');
+                } else if (response.status === 403) {
+                    alert('This particular query was blocked due to spamming. If you think it\'s an error, please open an issue on GitHub.');
                 } else {
                     alert('An error occured...');
                 }

--- a/lib/server/controllers/apiController.js
+++ b/lib/server/controllers/apiController.js
@@ -23,6 +23,13 @@ var ApiController = function(app) {
             req.body.url = 'http://' + req.body.url;
         }
 
+        // Block requests to unwanted websites (=spam)
+        if (isBlocked(req.body.url)) {
+            console.error('Test blocked for URL: %s', req.body.url);
+            res.status(403).send('Forbidden');
+            return;
+        }
+
         // Grab the test parameters and generate a random run ID
         var run = {
             runId: (Date.now()*1000 + Math.round(Math.random()*1000)).toString(36),
@@ -86,6 +93,7 @@ var ApiController = function(app) {
             return ylt(run.params.url, runOptions);
 
         })
+
         // Phantomas completed, let's save the screenshot if any
         .then(function(data) {
 
@@ -327,6 +335,11 @@ var ApiController = function(app) {
             });
     });
 
+    function isBlocked(url) {
+        return serverSettings.blockedUrls.some(function(blockedUrl) {
+            return (url.indexOf(blockedUrl) === 0);
+        });
+    }
 };
 
 module.exports = ApiController;

--- a/lib/server/controllers/apiController.js
+++ b/lib/server/controllers/apiController.js
@@ -336,6 +336,10 @@ var ApiController = function(app) {
     });
 
     function isBlocked(url) {
+        if (!serverSettings.blockedUrls) {
+            return false;
+        }
+
         return serverSettings.blockedUrls.some(function(blockedUrl) {
             return (url.indexOf(blockedUrl) === 0);
         });

--- a/server_config/settings-prod.json
+++ b/server_config/settings-prod.json
@@ -8,5 +8,6 @@
         
     },
     "maxAnonymousRunsPerDay": 99999999,
-    "maxAnonymousCallsPerDay": 99999999
+    "maxAnonymousCallsPerDay": 99999999,
+    "blockedUrls": []
 }

--- a/server_config/settings.json
+++ b/server_config/settings.json
@@ -8,5 +8,6 @@
         
     },
     "maxAnonymousRunsPerDay": 99999999,
-    "maxAnonymousCallsPerDay": 99999999
+    "maxAnonymousCallsPerDay": 99999999,
+    "blockedUrls": []
 }

--- a/test/api/apiTest.js
+++ b/test/api/apiTest.js
@@ -687,4 +687,29 @@ describe('api', function() {
         });
     });
 
+    it('should refuse a query on a blocked Url', function(done) {
+        this.timeout(5000);
+
+        request({
+            method: 'POST',
+            url: serverUrl + '/api/runs',
+            body: {
+                url: 'http://www.test.com/something.html',
+                waitForResponse: false
+            },
+            json: true,
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }, function(error, response, body) {
+            console.log(error);
+            console.log(response);
+            if (!error && response.statusCode === 403) {
+                done();
+            } else {
+                done(error || response.statusCode);
+            }
+        });
+    });
+
 });

--- a/test/api/apiTest.js
+++ b/test/api/apiTest.js
@@ -699,11 +699,10 @@ describe('api', function() {
             },
             json: true,
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-Api-Key': Object.keys(config.authorizedKeys)[0]
             }
         }, function(error, response, body) {
-            console.log(error);
-            console.log(response);
             if (!error && response.statusCode === 403) {
                 done();
             } else {

--- a/test/fixtures/settings.json
+++ b/test/fixtures/settings.json
@@ -8,5 +8,8 @@
         "1234567890": "contact@gaelmetais.com"
     },
     "maxAnonymousRunsPerDay": 10,
-    "maxAnonymousCallsPerDay": 1000
+    "maxAnonymousCallsPerDay": 1000,
+    "blockedUrls": [
+        "http://www.test.com"
+    ]
 }


### PR DESCRIPTION
I've noticed that YLT was used by some ******** to improve their access stats.
This change adds a list of blocked urls to the settings.