### PR TITLE
Add file names to duplicated css selectors offenders

### DIFF
--- a/front/src/views/rule.html
+++ b/front/src/views/rule.html
@@ -117,10 +117,6 @@
                         <file-and-line-button file="offender.file" line="offender.line" column="offender.column"></file-and-line-button>
                     </div>
 
-                    <div ng-if="policyName === 'cssDuplicatedSelectors'">
-                        {{offender.rule}} (<b>x{{offender.occurrences}}</b>)
-                    </div>
-
                     <div ng-if="policyName === 'cssOldPropertyPrefixes'">
                         <b>{{offender.property}} {{offender.message}}</b>
                         <div ng-if="offender.rules.length" ng-click="offender.showMore = !offender.showMore" class="offenderButton">
@@ -186,6 +182,10 @@
                     <div ng-if="policyName === 'cssMobileFirst'">
                         <b>{{offender.query}}</b> for <ng-pluralize count="offender.rules" when="{'one':'1 rule','other':'{} rules'}"></ng-pluralize>
                         <span ng-if="offender.line !== null && offender.column !== null"> @ {{offender.line}}:{{offender.column}}</span>
+                    </div>
+
+                    <div ng-if="policyName === 'cssDuplicatedSelectors'">
+                        {{offender.rule}} (<b>x{{offender.occurrences}}</b>)
                     </div>
 
                     <div ng-if="policyName === 'cssDuplicatedProperties'">

--- a/lib/metadata/policies.js
+++ b/lib/metadata/policies.js
@@ -596,24 +596,24 @@ var policies = {
         "isAbnormalThreshold": 100,
         "hasOffenders": true,
         "offendersTransformFn": function(offenders) {
-            return {
-                count: offenders.length,
-                list: offenders.map(function(offender) {
-                    var parts = /^(.*) \((\d+) times\)$/.exec(offender);
+            var parsedOffenders = offenders.map(function(offender) {
+                var parts = /^(.*) \((\d+) times\) ?<(.*)>$/.exec(offender);
 
-                    if (!parts) {
-                        debug('cssDuplicatedSelectors offenders transform function error with "%s"', offender);
-                        return {
-                            parseError: offender
-                        };
-                    }
-
+                if (!parts) {
+                    debug('cssDuplicatedSelectors offenders transform function error with "%s"', offender);
                     return {
-                        rule: parts[1],
-                        occurrences: parseInt(parts[2], 10)
+                        parseError: offender
                     };
-                })
-            };
+                }
+
+                return {
+                    rule: parts[1],
+                    occurrences: parseInt(parts[2], 10),
+                    file: parts[3]
+                };
+            });
+
+            return offendersHelpers.orderByFile(parsedOffenders);
         }
     },
     "cssDuplicatedProperties": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "meow": "3.7.0",
     "minimize": "2.0.0",
     "parse-color": "1.0.0",
-    "phantomas": "1.18.0",
+    "phantomas": "1.19.0",
     "ps-node": "0.1.4",
     "q": "1.4.1",
     "request": "2.79.0",


### PR DESCRIPTION
Fixes #230.

- Phantomas updated to v1.19.0
- Grouped duplicated selectors by file urls

Adding line numbers would be too complicated in this case.