### PR TITLE
Ignore unused fonts

### DIFF
--- a/lib/tools/redownload/fontAnalyzer.js
+++ b/lib/tools/redownload/fontAnalyzer.js
@@ -57,8 +57,17 @@ var FontAnalyzer = function() {
             var endTime = Date.now();
             debug('Font analysis took %dms', endTime - startTime);
 
-            deferred.resolve(result);
+            // Mark fonts that are not used on the page (#224)
+            var fontIsUsed = false;
+            for (var range in result.unicodeRanges) {
+                if (result.unicodeRanges[range].numGlyphsInCommonWithPageContent > 0) {
+                    fontIsUsed = true;
+                    break;
+                }
+            }
+            result.isUsed = fontIsUsed;
 
+            deferred.resolve(result);
         } catch(error) {
             deferred.reject(error);
         }

--- a/lib/tools/redownload/redownload.js
+++ b/lib/tools/redownload/redownload.js
@@ -103,6 +103,14 @@ var Redownload = function() {
                 var metrics = {};
                 var offenders = {};
 
+                // Remove unused fonts that a normal browser would not download (fix #224)
+                results = results.filter(function(result) {
+                    if (result && result.fontMetrics) {
+                        return result.fontMetrics.isUsed !== false;
+                    }
+                    return true;
+                });
+
                 // Count requests
                 offenders.totalRequests = listRequestsByType(results);
                 metrics.totalRequests = offenders.totalRequests.total;


### PR DESCRIPTION
Fix for #224:

Until a future version of PhantomJS handles fonts correctly (doesn't download a font subset that's not used), this is a quick fix that should work at 99%. It compares the glyphes used on the page with the glyphes in the font.