### PR TITLE
Fix "ReferenceError: ga is not defined"

### DIFF
--- a/front/src/js/app.js
+++ b/front/src/js/app.js
@@ -35,7 +35,7 @@ yltApp.run(['$rootScope', '$location', function($rootScope, $location) {
 
     // Google Analytics
     $rootScope.$on('$routeChangeSuccess', function(){
-        if (ga) {
+        if (typeof ga !== "undefined") {
             ga('send', 'pageview', {'page': $location.path()});
         }
     });


### PR DESCRIPTION
After updating to v1.13, Google Analytics is no longer loaded, but unfortunately this is not checked correctly, causing a ReferenceError to be thrown.