### PR TITLE
Load Github buttons over HTTPS

### DIFF
--- a/front/src/js/app.js
+++ b/front/src/js/app.js
@@ -42,7 +42,7 @@ yltApp.run(['$rootScope', '$location', function($rootScope, $location) {
 
     // GitHub star button (asynchronously loaded iframe)
     window.addEventListener('load', function() {
-        window.document.getElementById('ghbtn').src = 'http://ghbtns.com/github-btn.html?user=gmetais&repo=YellowLabTools&type=star&count=true&size=large';
+        window.document.getElementById('ghbtn').src = 'https://ghbtns.com/github-btn.html?user=gmetais&repo=YellowLabTools&type=star&count=true&size=large';
     });
 }]);
 


### PR DESCRIPTION
This fixes a mixed content error when loading YLT over HTTPS.